### PR TITLE
Fix bug that Configuration#manifests returns manifest object with nil path

### DIFF
--- a/lib/minipack/configuration.rb
+++ b/lib/minipack/configuration.rb
@@ -136,6 +136,9 @@ module Minipack
         #  Determine if a single manifest mode or multiple manifests(multiple site) mode
         targets =  @children.empty? ? [self] : @children.values
         targets.each do |config|
+          # Skip sites that a manifest file is not configured
+          next if config.manifest.nil?
+
           repo.add(config.id, config.manifest, cache: config.cache)
         end
         repo

--- a/spec/minipack/configuration_spec.rb
+++ b/spec/minipack/configuration_spec.rb
@@ -173,6 +173,26 @@ RSpec.describe Minipack::Configuration do
 
       it { expect { subject }.to raise_error described_class::Error }
     end
+
+    # This case is not usual, but we care about this.
+    context 'when a site is configured, but manifest is not specified' do
+      let(:config) do
+        described_class.new.tap do |c|
+          c.add :shop do |co|
+            co.manifest = 'shop/manifest.json'
+          end
+          c.add :admin
+        end
+      end
+
+      it { is_expected.to be_a Minipack::ManifestRepository }
+      it 'registers manifests as expected' do
+        expect(subject.all_manifests.size).to eq 1
+      end
+      it 'the manifest path given is registered' do
+        expect(subject.get(:shop).path).to eq 'shop/manifest.json'
+      end
+    end
   end
 
   describe '#manifest=' do


### PR DESCRIPTION
`Minipack::Configuration#manifests` must have returned only manifests which path is configured.