### PR TITLE
Add ability to instruct minipack if CSS will be in the manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ Minipack.configuration do |c|
   # Register a path to a manifest file here. Right now you have to specify an absolute path.
   c.manifest = Rails.root.join('public', 'assets', 'manifest.json')
 
+  # If you are not extracting CSS in your webpack config you should set this flag to false
+  # c.extract_css = !Rails.env.development?
+
   # The base directory for the frontend system. By default, it will be
   # `Rails.root`.
   # c.base_path = Rails.root

--- a/lib/minipack/configuration.rb
+++ b/lib/minipack/configuration.rb
@@ -79,6 +79,9 @@ module Minipack
       # The command for installation of npm packages
       config_attr :pkg_install_command, default: 'npm install'
 
+      # Disable if you're webpack configuration is not extracting CSS files
+      config_attr :extract_css, default: true
+
       # Let me leave this line for remember the indea of post pkg install hooks
       # config_attr :post_install_hooks, default: []
 
@@ -162,6 +165,13 @@ module Minipack
       # @return [String]
       def cache_path
         File.join(root_path, 'tmp', 'cache', 'minipack')
+      end
+
+      # CSS is extracted in the webpack build
+      #
+      # @return [Boolean]
+      def extract_css?
+        extract_css
       end
 
       private

--- a/lib/minipack/helper.rb
+++ b/lib/minipack/helper.rb
@@ -52,7 +52,9 @@ module Minipack::Helper
   #   <link rel="stylesheet" media="screen"
   #    href="/assets/web/pack/orders/style-1016838bab065ae1e122.css" />
   def stylesheet_bundle_tag(*names, manifest: nil, **options)
-    stylesheet_link_tag(*sources_from_manifest(names, 'css', key: manifest), **options)
+    if Minipack.configuration.extract_css?
+      stylesheet_link_tag(*sources_from_manifest(names, 'css', key: manifest), **options)
+    end
   end
 
   # Creates link tags that references the css chunks from entrypoints when using split chunks API.
@@ -69,7 +71,9 @@ module Minipack::Helper
   # <%= stylesheet_bundles_with_chunks_tag 'calendar' %>
   # <%= stylesheet_bundles_with_chunks_tag 'map' %>
   def stylesheet_bundles_with_chunks_tag(*names, manifest: nil, **options)
-    stylesheet_link_tag(*sources_from_manifest_entrypoints(names, 'css', key: manifest), **options)
+    if Minipack.configuration.extract_css?
+      stylesheet_link_tag(*sources_from_manifest_entrypoints(names, 'css', key: manifest), **options)
+    end
   end
 
   # Examples:

--- a/spec/minipack/helper_spec.rb
+++ b/spec/minipack/helper_spec.rb
@@ -267,6 +267,24 @@ RSpec.describe Minipack::Helper do
         is_expected.to raise_error Minipack::Manifest::MissingEntryError
       end
     end
+
+    context 'given css is not extracted' do
+      let(:configuration) do
+        Minipack::Configuration.new.tap do |c|
+          c.extract_css = false
+        end
+      end
+
+      context 'stylesheet_bundle_tag' do
+        subject { helper.stylesheet_bundle_tag('item_group_editor') }
+        it { is_expected.to eq nil }
+      end
+
+      context 'stylesheet_bundles_with_chunks_tag' do
+        subject { helper.stylesheet_bundle_tag('item_group_editor') }
+        it { is_expected.to eq nil }
+      end
+    end
   end
 
   describe '#image_bundle_tag' do


### PR DESCRIPTION
### WHY

Its common in development versions of WebPack to not extract CSS. In this situation we cannot use MiniPack as it will fail to load the non-existent CSS.

I copied the config variable name from WebPacker.