### PR TITLE
Support manifest files that have integrity hashes in them

### DIFF
--- a/lib/minipack/manifest.rb
+++ b/lib/minipack/manifest.rb
@@ -59,7 +59,13 @@ module Minipack
         # http url
         data = u.read
       end
-      JSON.parse(data)
+      transform_data(data)
+    end
+
+    def transform_data(data)
+      JSON.parse(data).each_with_object({}) { |(key, value), obj|
+        obj[key] = value.is_a?(String) ? { 'src' => value } : value
+      }
     end
 
     # The `manifest_name` method strips of the file extension of the name, because in the

--- a/spec/minipack/helper_spec.rb
+++ b/spec/minipack/helper_spec.rb
@@ -86,6 +86,28 @@ RSpec.describe Minipack::Helper do
       end
     end
 
+    context 'with a manifest with integrity hashes' do
+      let(:manifest_path) { File.expand_path('../support/files/manifest_with_integrity.json', __dir__) }
+
+      context 'given existing *.css entry name' do
+        subject { helper.javascript_bundle_tag('item_group_editor') }
+
+        it 'renders a nice <script> tag' do
+          is_expected.to eq '<script src="/packs/item_group_editor-857e5bfa272e71b6384046f68ba29d44.js" ' +
+            'integrity="sha512-euHN+g2i1Ae8+kzf7QG2JKTn0T2Yfd/g0Ob5c4gf7eE6R/TwzyQLwFFPiLyqValDNcOoROexTZXYwwe23GkFWQ=="></script>'
+        end
+      end
+
+      context 'given existing *.css entry name symbol' do
+        subject { helper.javascript_bundle_tag(:item_group_editor) }
+
+        it 'renders a nice <script> tag' do
+          is_expected.to eq '<script src="/packs/item_group_editor-857e5bfa272e71b6384046f68ba29d44.js" ' +
+            'integrity="sha512-euHN+g2i1Ae8+kzf7QG2JKTn0T2Yfd/g0Ob5c4gf7eE6R/TwzyQLwFFPiLyqValDNcOoROexTZXYwwe23GkFWQ=="></script>'
+        end
+      end
+    end
+
     context 'with multiple manifests registration and with manifest: option' do
       subject { helper.javascript_bundle_tag('admin-application', manifest: :admin) }
 
@@ -184,6 +206,28 @@ RSpec.describe Minipack::Helper do
 
       it 'renders a nice <link> tag' do
         is_expected.to eq '<link rel="stylesheet" media="screen" href="/packs/item_group_editor-5d7c7164b8a0a9d675fad9ab410eaa8d.css" />'
+      end
+    end
+
+    context 'with a manifest with integrity hashes' do
+      let(:manifest_path) { File.expand_path('../support/files/manifest_with_integrity.json', __dir__) }
+
+      context 'given existing *.css entry name' do
+        subject { helper.stylesheet_bundle_tag('item_group_editor') }
+
+        it 'renders a nice <link> tag' do
+          is_expected.to eq '<link rel="stylesheet" media="screen" href="/packs/item_group_editor-5d7c7164b8a0a9d675fad9ab410eaa8d.css" ' +
+            'integrity="sha512-cX6g/38/YkwmjsyyROJOwTBashVXq7PW8afhg/9ootKPE9HSr5JsnvbR+xbdjL40zZjKz3kJHd3Hh03O4h7P3A==" />'
+        end
+      end
+
+      context 'given existing *.css entry name symbol' do
+        subject { helper.stylesheet_bundle_tag(:item_group_editor) }
+
+        it 'renders a nice <link> tag' do
+          is_expected.to eq '<link rel="stylesheet" media="screen" href="/packs/item_group_editor-5d7c7164b8a0a9d675fad9ab410eaa8d.css" ' +
+            'integrity="sha512-cX6g/38/YkwmjsyyROJOwTBashVXq7PW8afhg/9ootKPE9HSr5JsnvbR+xbdjL40zZjKz3kJHd3Hh03O4h7P3A==" />'
+        end
       end
     end
 

--- a/spec/minipack/manifest_spec.rb
+++ b/spec/minipack/manifest_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Minipack::Manifest do
     context 'when entry is matched by name' do
       let(:name) { 'test.js' }
 
-      it { is_expected.to eq '/assets/web/pack/test-9a55da116417a39a9d1b.js' }
+      it { is_expected.to eq({ 'src' => '/assets/web/pack/test-9a55da116417a39a9d1b.js' }) }
     end
 
     context 'when non exit name is given' do
@@ -77,9 +77,16 @@ RSpec.describe Minipack::Manifest do
 
   describe '#load_data' do
     subject { described_class.new(path).send(:load_data) }
+    let(:parsed_path) { File.expand_path('../support/files/manifest_parsed.json', __dir__).to_s }
 
     context 'when given manifest is exist' do
       let(:path) { File.expand_path('../support/files/manifest.json', __dir__) }
+
+      it { is_expected.to eq JSON.parse(File.read(parsed_path)) }
+    end
+
+    context 'when given manifest with integrity data exists' do
+      let(:path) { File.expand_path('../support/files/manifest_with_integrity.json', __dir__) }
 
       it { is_expected.to eq JSON.parse(File.read(path)) }
     end
@@ -87,7 +94,7 @@ RSpec.describe Minipack::Manifest do
     context 'when Pathname object is given' do
       let(:path) { Pathname.new(File.expand_path('../support/files/manifest.json', __dir__)) }
 
-      it { is_expected.to eq JSON.parse(File.read(path.to_s)) }
+      it { is_expected.to eq JSON.parse(File.read(parsed_path)) }
     end
 
     context 'when an uri is given' do
@@ -99,7 +106,7 @@ RSpec.describe Minipack::Manifest do
                         read: data)
       end
       let(:data) do
-        { 'foo.js' => '/assets/foo-9a55da116417a39a9d1b.js.json' }.to_json
+        { 'foo.js' => { src: '/assets/foo-9a55da116417a39a9d1b.js.json' } }.to_json
       end
 
       before { allow(URI).to receive(:parse).and_return(stub_uri) }

--- a/spec/support/files/manifest_parsed.json
+++ b/spec/support/files/manifest_parsed.json
@@ -1,0 +1,29 @@
+{
+  "test.js": { "src": "/assets/web/pack/test-9a55da116417a39a9d1b.js" },
+  "dummy_thumbnail.png": { "src": "/assets/web/pack/dummy_thumbnail-757606db2b4802bb4147a968315df2df.png" },
+  "icon/avatar.png": { "src": "/assets/web/pack/icon/avatar-50b0773f02d0149e39468afa4b6567af.png" },
+  "item_group_editor.css": { "src": "/packs/item_group_editor-5d7c7164b8a0a9d675fad9ab410eaa8d.css" },
+  "item_group_editor.js": { "src": "/packs/item_group_editor-857e5bfa272e71b6384046f68ba29d44.js" },
+  "item_group_editor.js.map": { "src": "/packs/item_group_editor.js.map" },
+  "union-ok.png": { "src": "/packs/union-ok-857e5bfa272e71b6384046f68ba29d44.png" },
+  "union-ok@2x.png": { "src": "/packs/union-ok@2x-5d7c7164b8a0a9d675fad9ab410eaa8d.png" },
+  "entrypoints": {
+    "application": {
+      "js": [
+        "/packs/vendors~application~bootstrap-c20632e7baf2c81200d3.chunk.js",
+        "/packs/vendors~application-e55f2aae30c07fb6d82a.chunk.js",
+        "/packs/application-k344a6d59eef8632c9d1.js"
+      ],
+      "css": [
+        "/packs/1-c20632e7baf2c81200d3.chunk.css",
+        "/packs/application-k344a6d59eef8632c9d1.chunk.css"
+      ]
+    },
+    "hello_stimulus": {
+      "css": [
+        "/packs/1-c20632e7baf2c81200d3.chunk.css",
+        "/packs/hello_stimulus-k344a6d59eef8632c9d1.chunk.css"
+      ]
+    }
+  }
+}

--- a/spec/support/files/manifest_with_integrity.json
+++ b/spec/support/files/manifest_with_integrity.json
@@ -1,0 +1,34 @@
+{
+  "test.js": {
+    "src": "/assets/web/pack/test-9a55da116417a39a9d1b.js",
+    "integrity": "sha512-ANSU8GxSUPJ+dfC59rX0YtCxb26kdxW/lC3/5xgbwYnsyTBEcDKB2OIfuaiEjBno6+wPwiyfVk++XFOhXexp2Q=="
+  },
+  "dummy_thumbnail.png": {
+    "src": "/assets/web/pack/dummy_thumbnail-757606db2b4802bb4147a968315df2df.png",
+    "integrity": "sha512-Bo1aDhwY3N8vLA4PXpAU0wC+DDgcJNihlo/2WJ7iPX2N8jR8glbbwjaimnn3PZFWk+Q9dxDcmO6+TbsfnEw8PQ=="
+  },
+  "icon/avatar.png": {
+    "src": "/assets/web/pack/icon/avatar-50b0773f02d0149e39468afa4b6567af.png",
+    "integrity": "sha512-MKvhaiKL+m9sMJ4EkFRLB2Rcie46LegqPSHpBp/+fo87+RiJZ7zhpe9flUQyMuuii0RHnEbUl/5YlEz5FIy7EA=="
+  },
+  "item_group_editor.css": {
+    "src": "/packs/item_group_editor-5d7c7164b8a0a9d675fad9ab410eaa8d.css",
+    "integrity": "sha512-cX6g/38/YkwmjsyyROJOwTBashVXq7PW8afhg/9ootKPE9HSr5JsnvbR+xbdjL40zZjKz3kJHd3Hh03O4h7P3A=="
+  },
+  "item_group_editor.js": {
+    "src": "/packs/item_group_editor-857e5bfa272e71b6384046f68ba29d44.js",
+    "integrity": "sha512-euHN+g2i1Ae8+kzf7QG2JKTn0T2Yfd/g0Ob5c4gf7eE6R/TwzyQLwFFPiLyqValDNcOoROexTZXYwwe23GkFWQ=="
+  },
+  "item_group_editor.js.map": {
+    "src": "/packs/item_group_editor.js.map",
+    "integrity": "sha512-mGgnaW9VRQ3FyF3SCat+rsznUoIQqaOFDcNWHNqxwQo5zqkvtefns2/2em6zF2BBFUoEd+ZGVELr8VkL0fWOpw=="
+  },
+  "union-ok.png": {
+    "src": "/packs/union-ok-857e5bfa272e71b6384046f68ba29d44.png",
+    "integrity": "sha512-NU7S1BhT3DI1LaoBZ1XmMTjX9aKNXWiLGdKRBr7Omurr5wrSdbR+fYsQJ6goK6aDCCo1h1pyDzprkINjFvssbg=="
+  },
+  "union-ok@2x.png": {
+    "src": "/packs/union-ok@2x-5d7c7164b8a0a9d675fad9ab410eaa8d.png",
+    "integrity": "sha512-MGsXvTM7WzLI/R0aw7r0zA2FjmeehedkJWhsQaZJAuaatH/H02wPLXWUr3YxRt/k6hEnG8b9vCaY03c2houmKA=="
+  }
+}


### PR DESCRIPTION
# Why

When using https://github.com/webdeveric/webpack-assets-manifest you can include integrity hashes, this adds support for manifests generated this way