### PR TITLE
Add support for integrity attribute when using experimental splitChunks

### DIFF
--- a/lib/minipack/helper.rb
+++ b/lib/minipack/helper.rb
@@ -41,7 +41,9 @@ module Minipack::Helper
   # <%= javascript_bundles_with_chunks_tag 'calendar' %>
   # <%= javascript_bundles_with_chunks_tag 'map' %>
   def javascript_bundles_with_chunks_tag(*names, manifest: nil, **options)
-    javascript_include_tag(*sources_from_manifest_entrypoints(names, 'js', key: manifest), **options)
+    sources_from_manifest_entrypoints(names, 'js', key: manifest).map { |entry|
+      javascript_include_tag(entry.path, **options_for(entry, options))
+    }.join("\n").html_safe
   end
 
   # Examples:
@@ -76,7 +78,9 @@ module Minipack::Helper
   # <%= stylesheet_bundles_with_chunks_tag 'map' %>
   def stylesheet_bundles_with_chunks_tag(*names, manifest: nil, **options)
     if Minipack.configuration.extract_css?
-      stylesheet_link_tag(*sources_from_manifest_entrypoints(names, 'css', key: manifest), **options)
+      sources_from_manifest_entrypoints(names, 'css', key: manifest).map { |entry|
+        stylesheet_link_tag(entry.path, **options_for(entry, options))
+      }.join("\n").html_safe
     end
   end
 
@@ -101,7 +105,7 @@ module Minipack::Helper
 
   def sources_from_manifest_entrypoints(names, type, key: nil)
     manifest = get_manifest_by_key(key)
-    names.map { |name| manifest.lookup_pack_with_chunks!(name, type: type).entries.map(&:path) }.flatten.uniq
+    names.map { |name| manifest.lookup_pack_with_chunks!(name, type: type).entries }.flatten.uniq
   end
 
   def get_manifest_by_key(key = nil)

--- a/spec/minipack/helper_spec.rb
+++ b/spec/minipack/helper_spec.rb
@@ -176,7 +176,7 @@ RSpec.describe Minipack::Helper do
       it 'renders tags for chunk assets' do
         is_expected.to eq(
           %(<script src="/packs/vendors~admin-application-e55f2aae30c07fb6d82a.chunk.js"></script>\n) +
-          %(<script src="/packs/admin-application-k344a6d59eef8632c9d1.js"></script>),
+          %(<script src="/packs/admin/admin-application-5d7c7164b8a0a9d675fad9ab410eaa8d.js"></script>),
         )
       end
     end
@@ -188,6 +188,22 @@ RSpec.describe Minipack::Helper do
 
       it 'raises' do
         is_expected.to raise_error Minipack::Manifest::MissingEntryError
+      end
+    end
+
+
+    context 'given existing *.js with integrity attribute' do
+      subject { helper.javascript_bundles_with_chunks_tag('item_group_editor') }
+
+      let(:manifest_path) { File.expand_path('../support/files/manifest_with_integrity.json', __dir__) }
+
+      it 'renders tags for chunk assets' do
+        is_expected.to eq(
+          %(<script src="/packs/item_group_editor-857e5bfa272e71b6384046f68ba29d44.js" ) +
+          %(integrity="sha512-euHN+g2i1Ae8+kzf7QG2JKTn0T2Yfd/g0Ob5c4gf7eE6R/TwzyQLwFFPiLyqValDNcOoROexTZXYwwe23GkFWQ=="></script>\n) +
+          %(<script src="/packs/vendors~item_group_editor-5d7c7164b8a0a9d675fad9ab410eaa8d.js" ) +
+          %(integrity="sha512-cX6g/38/YkwmjsyyROJOwTBashVXq7PW8afhg/9ootKPE9HSr5JsnvbR+xbdjL40zZjKz3kJHd3Hh03O4h7P3A=="></script>),
+        )
       end
     end
   end
@@ -327,6 +343,21 @@ RSpec.describe Minipack::Helper do
       context 'stylesheet_bundles_with_chunks_tag' do
         subject { helper.stylesheet_bundle_tag('item_group_editor') }
         it { is_expected.to eq nil }
+      end
+    end
+
+    context 'given existing *.css with integrity attribute' do
+      subject { helper.stylesheet_bundles_with_chunks_tag('item_group_editor', media: 'all') }
+
+      let(:manifest_path) { File.expand_path('../support/files/manifest_with_integrity.json', __dir__) }
+
+      it 'renders tags for chunk assets' do
+        is_expected.to eq(
+          %(<link rel="stylesheet" media="all" href="/packs/item_group_editor-5d7c7164b8a0a9d675fad9ab410eaa8d.css" ) +
+          %(integrity="sha512-cX6g/38/YkwmjsyyROJOwTBashVXq7PW8afhg/9ootKPE9HSr5JsnvbR+xbdjL40zZjKz3kJHd3Hh03O4h7P3A==" />\n) +
+          %(<link rel="stylesheet" media="all" href="/packs/vendors~item_group_editor-5d7c7164b8a0a9d675fad9ab410eaa8d.css" ) +
+          %(integrity="sha512-cX6g/38/YkwmjsyyROJOwTBashVXq7PW8afhg/9ootKPE9HSr5JsnvbR+xbdjL40zZjKz3kJHd3Hh03O4h7P3A==" />),
+        )
       end
     end
   end

--- a/spec/support/files/manifest-admin.json
+++ b/spec/support/files/manifest-admin.json
@@ -2,11 +2,14 @@
   "admin-application.css": "/packs/admin/admin-application-5d7c7164b8a0a9d675fad9ab410eaa8d.css",
   "admin-application.js": "/packs/admin/admin-application-5d7c7164b8a0a9d675fad9ab410eaa8d.js",
   "admin-icon.png": "/packs/admin/admin-icon-5d7c7164b8a0a9d675fad9ab410eaa8d.png",
+  "vendors~admin-application.js": "/packs/vendors~admin-application-e55f2aae30c07fb6d82a.chunk.js",
+  "1.css": "/packs/1-c20632e7baf2c81200d3.chunk.css",
+  "admin-hello_stimulus.css": "/packs/admin-hello_stimulus-k344a6d59eef8632c9d1.chunk.css",
   "entrypoints": {
     "admin-application": {
       "js": [
         "/packs/vendors~admin-application-e55f2aae30c07fb6d82a.chunk.js",
-        "/packs/admin-application-k344a6d59eef8632c9d1.js"
+        "/packs/admin/admin-application-5d7c7164b8a0a9d675fad9ab410eaa8d.js"
       ]
     },
    "admin-hello_stimulus": {

--- a/spec/support/files/manifest.json
+++ b/spec/support/files/manifest.json
@@ -7,6 +7,11 @@
   "item_group_editor.js.map": "/packs/item_group_editor.js.map",
   "union-ok.png": "/packs/union-ok-857e5bfa272e71b6384046f68ba29d44.png",
   "union-ok@2x.png": "/packs/union-ok@2x-5d7c7164b8a0a9d675fad9ab410eaa8d.png",
+  "vendors~application~bootstrap.js": "/packs/vendors~application~bootstrap-c20632e7baf2c81200d3.chunk.js",
+  "vendors~application.js": "/packs/vendors~application-e55f2aae30c07fb6d82a.chunk.js",
+  "application.js": "/packs/application-k344a6d59eef8632c9d1.js",
+  "hello_stimulus.css": "/packs/hello_stimulus-k344a6d59eef8632c9d1.chunk.css",
+  "1.css": "/packs/1-c20632e7baf2c81200d3.chunk.css",
   "entrypoints": {
     "application": {
       "js": [

--- a/spec/support/files/manifest_with_integrity.json
+++ b/spec/support/files/manifest_with_integrity.json
@@ -3,6 +3,10 @@
     "src": "/assets/web/pack/test-9a55da116417a39a9d1b.js",
     "integrity": "sha512-ANSU8GxSUPJ+dfC59rX0YtCxb26kdxW/lC3/5xgbwYnsyTBEcDKB2OIfuaiEjBno6+wPwiyfVk++XFOhXexp2Q=="
   },
+  "test.css": {
+    "src": "/assets/web/pack/test-9a55da116417a39a9d1b.css",
+    "integrity": "sha512-ANSU8GxSUPJ+dfC59rX0YtCxb26kdxW/lC3/5xgbwYnsyTBEcDKB2OIfuaiEjBno6+wPwiyfVk++XFOhXexp2Q=="
+  },
   "dummy_thumbnail.png": {
     "src": "/assets/web/pack/dummy_thumbnail-757606db2b4802bb4147a968315df2df.png",
     "integrity": "sha512-Bo1aDhwY3N8vLA4PXpAU0wC+DDgcJNihlo/2WJ7iPX2N8jR8glbbwjaimnn3PZFWk+Q9dxDcmO6+TbsfnEw8PQ=="
@@ -15,9 +19,17 @@
     "src": "/packs/item_group_editor-5d7c7164b8a0a9d675fad9ab410eaa8d.css",
     "integrity": "sha512-cX6g/38/YkwmjsyyROJOwTBashVXq7PW8afhg/9ootKPE9HSr5JsnvbR+xbdjL40zZjKz3kJHd3Hh03O4h7P3A=="
   },
+  "vendors~item_group_editor.css": {
+    "src": "/packs/vendors~item_group_editor-5d7c7164b8a0a9d675fad9ab410eaa8d.css",
+    "integrity": "sha512-cX6g/38/YkwmjsyyROJOwTBashVXq7PW8afhg/9ootKPE9HSr5JsnvbR+xbdjL40zZjKz3kJHd3Hh03O4h7P3A=="
+  },
   "item_group_editor.js": {
     "src": "/packs/item_group_editor-857e5bfa272e71b6384046f68ba29d44.js",
     "integrity": "sha512-euHN+g2i1Ae8+kzf7QG2JKTn0T2Yfd/g0Ob5c4gf7eE6R/TwzyQLwFFPiLyqValDNcOoROexTZXYwwe23GkFWQ=="
+  },
+  "vendors~item_group_editor.js": {
+    "src": "/packs/vendors~item_group_editor-5d7c7164b8a0a9d675fad9ab410eaa8d.js",
+    "integrity": "sha512-cX6g/38/YkwmjsyyROJOwTBashVXq7PW8afhg/9ootKPE9HSr5JsnvbR+xbdjL40zZjKz3kJHd3Hh03O4h7P3A=="
   },
   "item_group_editor.js.map": {
     "src": "/packs/item_group_editor.js.map",
@@ -30,5 +42,22 @@
   "union-ok@2x.png": {
     "src": "/packs/union-ok@2x-5d7c7164b8a0a9d675fad9ab410eaa8d.png",
     "integrity": "sha512-MGsXvTM7WzLI/R0aw7r0zA2FjmeehedkJWhsQaZJAuaatH/H02wPLXWUr3YxRt/k6hEnG8b9vCaY03c2houmKA=="
+  },
+  "entrypoints": {
+    "item_group_editor": {
+      "js": [
+        "/packs/item_group_editor-857e5bfa272e71b6384046f68ba29d44.js",
+        "/packs/vendors~item_group_editor-5d7c7164b8a0a9d675fad9ab410eaa8d.js"
+      ],
+      "css": [
+        "/packs/item_group_editor-5d7c7164b8a0a9d675fad9ab410eaa8d.css",
+        "/packs/vendors~item_group_editor-5d7c7164b8a0a9d675fad9ab410eaa8d.css"
+      ]
+    },
+    "test": {
+      "js": [
+        "/assets/web/pack/test-9a55da116417a39a9d1b.js"
+      ]
+    }
   }
 }


### PR DESCRIPTION
recently ported over from a dated legacy webpack config to using minipack and its great how customizable it is. took some time to add support for integrity attributes when using the splitChunks feature in webpack4.

all chunks that are nested within `entrypoints` have a top-level reference containing the `integrity` attribute when true in https://github.com/webdeveric/webpack-assets-manifest#integrity. 

then can search the manifest for that top-level reference to get the attribute and then pass it to the rails asset helper

tried to stick with the code style of the repository, let me know if theres any missing test cases you'd like to see and i can add those.