### PR TITLE
Fix duplicated shared chunks issue

### DIFF
--- a/lib/minipack/helper.rb
+++ b/lib/minipack/helper.rb
@@ -105,7 +105,7 @@ module Minipack::Helper
 
   def sources_from_manifest_entrypoints(names, type, key: nil)
     manifest = get_manifest_by_key(key)
-    names.map { |name| manifest.lookup_pack_with_chunks!(name, type: type).entries }.flatten.uniq
+    names.map { |name| manifest.lookup_pack_with_chunks!(name, type: type).entries }.flatten.uniq(&:path)
   end
 
   def get_manifest_by_key(key = nil)

--- a/spec/minipack/helper_spec.rb
+++ b/spec/minipack/helper_spec.rb
@@ -293,7 +293,19 @@ RSpec.describe Minipack::Helper do
       it 'renders tags for chunk assets' do
         is_expected.to eq(
           %(<link rel="stylesheet" media="all" href="/packs/1-c20632e7baf2c81200d3.chunk.css" />\n) +
-          %(<link rel="stylesheet" media="all" href="/packs/hello_stimulus-k344a6d59eef8632c9d1.chunk.css" />),
+          %(<link rel="stylesheet" media="all" href="/packs/hello_stimulus-k344a6d59eef8632c9d1.chunk.css" />)
+        )
+      end
+    end
+
+    context 'given multiple existing *.css entry names sharing chunks' do
+      subject { helper.stylesheet_bundles_with_chunks_tag('application', 'hello_stimulus') }
+
+      it 'renders tags for chunk assets without duplication' do
+        is_expected.to eq(
+          %(<link rel="stylesheet" media="screen" href="/packs/1-c20632e7baf2c81200d3.chunk.css" />\n) +
+          %(<link rel="stylesheet" media="screen" href="/packs/application-k344a6d59eef8632c9d1.chunk.css" />\n) +
+          %(<link rel="stylesheet" media="screen" href="/packs/hello_stimulus-k344a6d59eef8632c9d1.chunk.css" />)
         )
       end
     end

--- a/spec/support/files/manifest.json
+++ b/spec/support/files/manifest.json
@@ -10,6 +10,7 @@
   "vendors~application~bootstrap.js": "/packs/vendors~application~bootstrap-c20632e7baf2c81200d3.chunk.js",
   "vendors~application.js": "/packs/vendors~application-e55f2aae30c07fb6d82a.chunk.js",
   "application.js": "/packs/application-k344a6d59eef8632c9d1.js",
+  "application.css": "/packs/application-k344a6d59eef8632c9d1.chunk.css",
   "hello_stimulus.css": "/packs/hello_stimulus-k344a6d59eef8632c9d1.chunk.css",
   "1.css": "/packs/1-c20632e7baf2c81200d3.chunk.css",
   "entrypoints": {


### PR DESCRIPTION
Since every Entry object has a different 
object_id, a simple uniq won’t be enough. 
Instead, we should apply uniqueness based on 
the path attribute, otherwise shared chunks 
will be duplicated.