### PR TITLE
Add support for new webpack asset manifest format

### DIFF
--- a/lib/minipack/manifest.rb
+++ b/lib/minipack/manifest.rb
@@ -50,9 +50,11 @@ module Minipack
     def lookup_pack_with_chunks!(name, type: nil)
       manifest_pack_type = manifest_type(name, type)
       manifest_pack_name = manifest_name(name, manifest_pack_type)
-      paths = data['entrypoints']&.dig(manifest_pack_name, manifest_pack_type) || handle_missing_entry(name)
+      paths = data['entrypoints']&.dig(manifest_pack_name, manifest_pack_type) ||
+        data['entrypoints']&.dig(manifest_pack_name, 'assets', manifest_pack_type) ||
+        handle_missing_entry(name)
 
-      entries = data['entrypoints']&.dig(manifest_pack_name, manifest_pack_type).map do |source|
+      entries = paths.map do |source|
         entry_from_source(source) || handle_missing_entry(name)
       end
 
@@ -107,7 +109,7 @@ module Minipack
       JSON.parse(data)
     end
 
-    # The `manifest_name` method strips of the file extension of the name, because in the
+    # The `manifest_name` method strips off the file extension of the name, because in the
     # manifest hash the entrypoints are defined by their pack name without the extension.
     # When the user provides a name with a file extension, we want to try to strip it off.
     def manifest_name(name, pack_type)

--- a/spec/minipack/manifest_spec.rb
+++ b/spec/minipack/manifest_spec.rb
@@ -16,11 +16,10 @@ RSpec.describe Minipack::Manifest do
   describe '#lookup_pack_with_chunks!' do
     subject { described_class.new(path, cache: false).lookup_pack_with_chunks!(name, type: type) }
 
-    let(:path) { File.expand_path('../support/files/manifest.json', __dir__) }
-    let(:type) { nil }
-
     context 'with name with ext' do
+      let(:path) { File.expand_path('../support/files/manifest.json', __dir__) }
       let(:name) { 'application.js' }
+      let(:type) { nil }
 
       it do
         expected = Minipack::Manifest::ChunkGroup.new(
@@ -33,6 +32,7 @@ RSpec.describe Minipack::Manifest do
     end
 
     context 'with name without ext' do
+      let(:path) { File.expand_path('../support/files/manifest_with_prefetch.json', __dir__) }
       let(:name) { 'application' }
       let(:type) { 'js' }
 
@@ -47,7 +47,9 @@ RSpec.describe Minipack::Manifest do
     end
 
     context 'when non exist name is given' do
+      let(:path) { File.expand_path('../support/files/manifest.json', __dir__) }
       let(:name) { 'foo.js' }
+      let(:type) { nil }
 
       it { expect { subject }.to raise_error Minipack::Manifest::MissingEntryError }
     end

--- a/spec/support/files/manifest_with_prefetch.json
+++ b/spec/support/files/manifest_with_prefetch.json
@@ -1,0 +1,49 @@
+{
+  "test.js": "/assets/web/pack/test-9a55da116417a39a9d1b.js",
+  "dummy_thumbnail.png": "/assets/web/pack/dummy_thumbnail-757606db2b4802bb4147a968315df2df.png",
+  "icon/avatar.png": "/assets/web/pack/icon/avatar-50b0773f02d0149e39468afa4b6567af.png",
+  "item_group_editor.css": "/packs/item_group_editor-5d7c7164b8a0a9d675fad9ab410eaa8d.css",
+  "item_group_editor.js": "/packs/item_group_editor-857e5bfa272e71b6384046f68ba29d44.js",
+  "item_group_editor.js.map": "/packs/item_group_editor.js.map",
+  "union-ok.png": "/packs/union-ok-857e5bfa272e71b6384046f68ba29d44.png",
+  "union-ok@2x.png": "/packs/union-ok@2x-5d7c7164b8a0a9d675fad9ab410eaa8d.png",
+  "vendors~application~bootstrap.js": "/packs/vendors~application~bootstrap-c20632e7baf2c81200d3.chunk.js",
+  "vendors~application.js": "/packs/vendors~application-e55f2aae30c07fb6d82a.chunk.js",
+  "application.js": "/packs/application-k344a6d59eef8632c9d1.js",
+  "application.css": "/packs/application-k344a6d59eef8632c9d1.chunk.css",
+  "hello_stimulus.css": "/packs/hello_stimulus-k344a6d59eef8632c9d1.chunk.css",
+  "1.css": "/packs/1-c20632e7baf2c81200d3.chunk.css",
+  "entrypoints": {
+    "application": {
+      "assets": {
+        "js": [
+          "/packs/vendors~application~bootstrap-c20632e7baf2c81200d3.chunk.js",
+          "/packs/vendors~application-e55f2aae30c07fb6d82a.chunk.js",
+          "/packs/application-k344a6d59eef8632c9d1.js"
+        ],
+        "css": [
+          "/packs/1-c20632e7baf2c81200d3.chunk.css",
+          "/packs/application-k344a6d59eef8632c9d1.chunk.css"
+        ]
+      },
+      "prefetch": {
+        "js": [
+          "prefetch.js"
+        ]
+      },
+      "preload": {
+        "js": [
+          "preload.js"
+        ]
+      }
+    },
+    "hello_stimulus": {
+      "assets": {
+        "css": [
+          "/packs/1-c20632e7baf2c81200d3.chunk.css",
+          "/packs/hello_stimulus-k344a6d59eef8632c9d1.chunk.css"
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/nikushi/minipack/issues/39

webpack-asset-manifest introduced a new format in v4. In order to support prefetch and preload, assets are now nested under an assets key in the entrypoints object. This commit updates the manifest parsing logic to support this new version in addition to the previous.

More info on the manifest changes can be found [here](https://www.npmjs.com/package/webpack-assets-manifest#new-in-version-4)

NOTE: after making these changes, I noticed Szeliga has [a PR](https://github.com/nikushi/minipack/pull/40) that also solves this problem. I think the approach here is a lot simpler than adding a configuration option, although I suppose that might be more extensible in the future. I don't expect manifest formats to change often though, so I still prefer this solution personally. But merging either would solve my problem and make me happy =)