### PR TITLE
support ruby 3.x syntax by using ** descoping in `new` with hash inputs

### DIFF
--- a/lib/minipack/commands/base.rb
+++ b/lib/minipack/commands/base.rb
@@ -4,8 +4,8 @@ module Minipack
   module Commands
     class Base
       class << self
-        def call(*args)
-          new(*args).call
+        def call(**args)
+          new(**args).call
         end
       end
     end


### PR DESCRIPTION
## Description

I was trying to run ruby 3 in a project, which uses minipack.

unfortunately it seems that current way as the Commands::Base call the initialize method does not respect the new syntax.

This PR should fix it and still be compliant with recent versions of ruby.